### PR TITLE
Add name property to the plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function unique(defs) {
 }
 
 const graphqlPlugin = {
+  name: 'graphql-plugin',
   transforms: [{
     test({path}) {
       return path.endsWith('.gql') || path.endsWith('.graphql');


### PR DESCRIPTION
The name property is required to display error messages and logs. 

I also had an issue with `@nuxt/test-utils` that needed to match specific plugins name. Without the name it crashed.